### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,5 +1,8 @@
 name: 'test-build'
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/RahulARanger/handshake/security/code-scanning/15](https://github.com/RahulARanger/handshake/security/code-scanning/15)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are likely sufficient:
- `contents: read` for accessing repository files.
- Additional permissions (e.g., `actions: read`, `packages: read`) should only be added if specific jobs require them.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is sufficient and simplifies the configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
